### PR TITLE
Update JavaScript.md

### DIFF
--- a/Component Development/Coding Guidelines/JavaScript.md
+++ b/Component Development/Coding Guidelines/JavaScript.md
@@ -28,6 +28,9 @@ The following guidelines apply to JavaScript for components.
 
 - Verify usage of "this" in event handlers and callback functions.
 
+- Use Speak handler to reference assets rather than direct urls.
+
+
 ## Component-Specific Guidelines 
 
 - The model should expose all appropriate parameters.


### PR DESCRIPTION
I want to explain a little.
I found that in application css and js have urls with real pathes of Speak files.
Like "/sitecore/shell/client/Speak/Assets/lib/ui/1.1/userProfile.js". In the same time urls with Speak handled used like "/-/speak/v1/pathanalyzer/scripts/app/utils/eventManager.js".
So we need to agree what type of urls to use and make it consistent.
Both approaches have disadvantages.
